### PR TITLE
Update croatian.js

### DIFF
--- a/nem-client-api/src/main/webapp/scripts/languages/croatian.js
+++ b/nem-client-api/src/main/webapp/scripts/languages/croatian.js
@@ -1,6 +1,6 @@
 define({
 	id: 'hr',
-	name: 'hrvatski',
+	name: 'Hrvatski',
 	texts: {
 		preferences: {
 			thousandSeparator: ' ',


### PR DESCRIPTION
Tomislav Flis, [02.04.15 00:12]
It is correct because we say: hrvatski jezik (Croatian language) We don't write the names of languages in capital, but if you put every other language with capital 1. letter, than I would suggest doing the same with Croatian/hrvatski/Hrvatski...

Tomislav Flis, [02.04.15 00:14]
In this instance I would suggest changing it to Hrvatski... Mostly for esthetics and equality...